### PR TITLE
Make bucket and token/key hardcoded values settable

### DIFF
--- a/hisoka/management/commands/tweet.py
+++ b/hisoka/management/commands/tweet.py
@@ -26,9 +26,9 @@ class Command(BaseCommand):
             raise CommandError("No se reconocio nombre del Fireball")
 
         # Envia tweets de Orilla Libertaria a twitter
-        access_token_twitter = "1884663464-cKUFhmqTVbEvxbkdOD0rBo1UyXwX20ZrbtseIQc"
+        access_token_twitter = os.environ['ACCESS_TOKEN_TWITTER']
         access_token_twitter_secret = os.environ['ACCESS_TOKEN_TWITTER_SECRET']
-        consumer_key = "XwIbq6Zwl5rUYzIMheFwx9MXO"
+        consumer_key = os.environ['CONSUMER_KEY_TWITTER']
         consumer_secret = os.environ['CONSUMER_SECRET_TWITTER']
         auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
         auth.set_access_token(access_token_twitter, access_token_twitter_secret)

--- a/hisoka/models.py
+++ b/hisoka/models.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from datetime import datetime
 
+from django.conf import settings
 from django.db import models
 from django.template.defaultfilters import slugify
 
@@ -40,7 +41,7 @@ class FeralSpirit(models.Model):
     tipo = models.CharField(max_length=60)
     texto = models.CharField(max_length=150, blank=True)
     url = models.URLField(blank=True)
-    imagen = models.ImageField(null=True, blank=True, upload_to=ubicar_imagen_feral, storage=S3BotoStorage(bucket='criptolibertad'))
+    imagen = models.ImageField(null=True, blank=True, upload_to=ubicar_imagen_feral, storage=S3BotoStorage(bucket=settings.AWS_STORAGE_BUCKET_NAME))
     tema = models.CharField(max_length=150, blank=True)
     contador = models.PositiveIntegerField(default=0)
     ultima_publicacion = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
## Here's what I did

I first create an instance for testing:

```
from hisoka.models import Fireball, FeralSpirit
from django.core.files import File

fireball = Fireball.objects.create(nombre='OrillaLibertaria')
spirit = fireball.feralspirit_set.create(
    spirit.texto = 'Test CrHisoka'
    spirit.url = 'http://stackoverflow.com/questions/38134984/'
)

path = '/Users/pavel/dev/temp/so38134984/rainbow_dash2.png'
with open(path) as f:
    spirit.imagen.save(f.name, File(f))
    spirit.save()
```

And then simply run the management command:

```
python manage.py tweet orilla
```

The result is this tweet: https://twitter.com/asfaltboy/status/750590679995285504

Notice that the only changes here are adding the ability to use my own bucket and twitter
credentials. This means that this is almost certainly an issue with your AWS S3 bucket policy.

I suggest you re-read the relevant documentation here: http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-access-control.html
